### PR TITLE
PIZ-22: PIZ-22: Create GitHook Rule To Mandate Jira Ticket Reference …

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "In pre-commit hook."
+
+if [ -z "$SKIP_BRANCHES" ]; then
+    SKIP_BRANCHES=(master staging development)
+fi
+
+CURRENT_BRANCH_NAME=$(git symbolic-ref --short HEAD)
+
+BRANCH_EXCLUDED=$(printf "%s\n" "${SKIP_BRANCHES[@]}" | grep -c "^$CURRENT_BRANCH_NAME$")
+
+if [ "$BRANCH_EXCLUDED" -eq 1 ];
+then
+    exit 0;
+fi
+
+VALID_BRANCH_REGEX="^(feat|bug|improvement|release|hotfix)\/PIZ+-[0-9]+"
+
+ERROR_MESSAGE="Branch name is invalid. Branch names must be this regex: $VALID_BRANCH_REGEX. Your commit has been rejected. Rename your branch and try again."
+
+if [[ ! $CURRENT_BRANCH_NAME =~ $VALID_BRANCH_REGEX ]]
+then
+    echo "$ERROR_MESSAGE"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Creating branches will now fail in Git if the required format is not provided.

IE the format needs to be (feat/bug/improvement/release/hotfix)/PIZ-123/This-is-the-ticket-title